### PR TITLE
Add Fourier Analysis for training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+tony/logs/*
+tony/models/*
+operator/data/* 
+operator/train/*
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pinn/pinn_1d.py
+++ b/pinn/pinn_1d.py
@@ -388,7 +388,7 @@ def train(model, mesh, criterion, iterations, adam_iterations, learning_rate,
                 save_frame(x=to_np(mesh.x_eval), t=None, y=to_np(error),
                            xs=None, ys=None,
                            iteration=[sweep_idx, level_idx, i], title="Model_Errors", frame_dir=frame_dir)
-                fft_error = calculate_fourier_coefficients_error(u_analytic, u_eval, fourier_freqs=[1,4,9])
+                fft_error = calculate_fourier_coefficients_error(u_analytic.cpu().numpy(), u_eval.cpu().numpy(), fourier_freqs=[1,4,9])
                 fft_errors.append(fft_error)
 
             model.train()

--- a/pinn/pinn_1d.py
+++ b/pinn/pinn_1d.py
@@ -55,7 +55,7 @@ import torch.optim as optim
 from torch.optim.lr_scheduler import StepLR
 import numpy as np
 from enum import Enum
-from utils import parse_args, get_activation, print_args, save_frame, make_video_from_frames, is_notebook, cleanfiles
+from utils import parse_args, get_activation, print_args, save_frame, make_video_from_frames, is_notebook, cleanfiles, calculate_fourier_coefficients_error, FourierData
 from SOAP.soap import SOAP
 
 # torch.set_default_dtype(torch.float64)
@@ -336,6 +336,8 @@ def train(model, mesh, criterion, iterations, adam_iterations, learning_rate,
     u_analytic = mesh.pde.u_ex(mesh.x_eval)
     check_freq = (iterations + num_check - 1) // num_check
     plot_freq = (iterations + num_plots - 1) // num_plots if num_plots > 0 else 0
+    fft_errors = FourierData.placeholder()
+
 
     for i in range(iterations):
         if i == adam_iterations:
@@ -386,6 +388,9 @@ def train(model, mesh, criterion, iterations, adam_iterations, learning_rate,
                 save_frame(x=to_np(mesh.x_eval), t=None, y=to_np(error),
                            xs=None, ys=None,
                            iteration=[sweep_idx, level_idx, i], title="Model_Errors", frame_dir=frame_dir)
+                fft_error = calculate_fourier_coefficients_error(u_analytic, u_eval, fourier_freqs=[1,4,9])
+                fft_errors.append(fft_error)
+
             model.train()
 
 # %%

--- a/pinn/utils.py
+++ b/pinn/utils.py
@@ -166,3 +166,7 @@ def calculate_fourier_coefficients(u:list[float], fourier_freqs:list[int])->Four
     Bk = np.abs(Bk)
     return FourierData(sin_coeffs=Bk, 
                        cos_coeffs=Ak, fourier_freqs=fourier_freqs)
+
+def calculate_fourier_coefficients_error(u1:list[float], u2:list[float], fourier_freqs:list[int])->FourierData:
+    error_vec = u1 - u2
+    return calculate_fourier_coefficients(error_vec, fourier_freqs)

--- a/pinn/utils.py
+++ b/pinn/utils.py
@@ -150,9 +150,29 @@ def make_video_from_frames(frame_dir, name_prefix, output_file, fps=10):
     print(f"  Video saved as {output_file_path}")
 
 class FourierData(NamedTuple):
-    sin_coeffs: list[float]
-    cos_coeffs: list[float]
-    fourier_freqs: list[float]
+    sin_coeffs: np.ndarray # 1D
+    cos_coeffs: np.ndarray # 1D
+    fourier_freqs: np.ndarray # 1D
+
+    def append(self, other: 'FourierData') -> 'FourierData':
+        assert self.fourier_freqs == other.fourier_freqs, "Fourier frequencies must match to append."
+
+        arrs = [self.sin_coeffs, other.sin_coeffs, self.cos_coeffs, other.cos_coeffs]
+
+        for arr in arrs: 
+            if len(arr.shape) == 1:
+                arr = arr[:, np.newaxis]
+
+        sin_coeffs = np.stack([arrs[0], arrs[1]], axis=-1)
+        cos_coeffs = np.stack([arrs[2], arrs[3]], axis=-1)
+
+        return FourierData(
+            sin_coeffs=sin_coeffs,
+            cos_coeffs=cos_coeffs,
+            fourier_freqs=self.fourier_freqs
+        )
+
+
 
 def calculate_fourier_coefficients(u:list[float], fourier_freqs:list[int])->FourierData:
     fft_u = fft.fft(u)

--- a/pinn/utils.py
+++ b/pinn/utils.py
@@ -155,6 +155,8 @@ class FourierData(NamedTuple):
     fourier_freqs: np.ndarray # 1D
 
     def append(self, other: 'FourierData') -> 'FourierData':
+        if self.sin_coeffs.shape[0]==0: # Empty self, return other
+            return other
         assert self.fourier_freqs == other.fourier_freqs, "Fourier frequencies must match to append."
 
         arrs = [self.sin_coeffs, other.sin_coeffs, self.cos_coeffs, other.cos_coeffs]
@@ -171,7 +173,12 @@ class FourierData(NamedTuple):
             cos_coeffs=cos_coeffs,
             fourier_freqs=self.fourier_freqs
         )
-
+    def placeholder()-> 'FourierData':
+        return FourierData(
+            sin_coeffs=np.array([]),
+            cos_coeffs=np.array([]),
+            fourier_freqs=np.array([])
+        )
 
 
 def calculate_fourier_coefficients(u:list[float], fourier_freqs:list[int])->FourierData:

--- a/pinn/utils.py
+++ b/pinn/utils.py
@@ -4,8 +4,10 @@ import torch.nn as nn
 import matplotlib.pyplot as plt
 import cv2
 from pathlib import Path
+import scipy.fft as fft
 import shutil
-
+import numpy as np
+from typing import NamedTuple
 
 def cleanfiles(dir_name):
     dir_path = Path(dir_name)
@@ -147,5 +149,20 @@ def make_video_from_frames(frame_dir, name_prefix, output_file, fps=10):
     video.release()
     print(f"  Video saved as {output_file_path}")
 
-def calculate_fourier_coefficients(u_pred, u_exact):
-    pass
+class FourierData(NamedTuple):
+    sin_coeffs: list[float]
+    cos_coeffs: list[float]
+    fourier_freqs: list[float]
+
+def calculate_fourier_coefficients(u:list[float], fourier_freqs:list[int])->FourierData:
+    fft_u = fft.fft(u)
+    N = len(u)
+    # A_k (cosine component): Ak = 2 * Re(Xk) / N
+    Ak = 2 * fft_u[fourier_freqs].real / N 
+    # B_k (sine component): Bk = -2 * Im(Xk) / N
+    Bk = 2 * fft_u[fourier_freqs].imag / N 
+
+    Ak = np.abs(Ak)
+    Bk = np.abs(Bk)
+    return FourierData(sin_coeffs=Bk, 
+                       cos_coeffs=Ak, fourier_freqs=fourier_freqs)

--- a/pinn/utils.py
+++ b/pinn/utils.py
@@ -146,3 +146,6 @@ def make_video_from_frames(frame_dir, name_prefix, output_file, fps=10):
         video.write(img)
     video.release()
     print(f"  Video saved as {output_file_path}")
+
+def calculate_fourier_coefficients(u_pred, u_exact):
+    pass


### PR DESCRIPTION
This PR adds fourier analysis for comparing analytical solution to predicted solution. I introduce the following functionality:

1. `def calculate_fourier_coefficients(u:list[float], fourier_freqs:list[int])->FourierData:`:  get the fourier transform of the signal `u`. 
2. `def calculate_fourier_coefficients_error(u1:list[float], u2:list[float], fourier_freqs:list[int])->FourierData`: get the fourier transform of the residual `u1-u2`. Noted that the function get absolute value of coefficient, so the order of u1 and u2 does not matter
3. `class FourierData(NamedTuple)`: a datatype for storing cosine and sine coefficients. Also, the corresponding frequencies.





**Reference**
1. [Tony's code for FFT](https://github.com/liruipeng/ml2/blob/10f7f7dae4eeabbead9d179cc0fdc12587a2392e/tony/analysis/fourier.py#L6-L101)