### PR TITLE
Remove verbose from `ReduceLRonPlateau`

### DIFF
--- a/tony/test_poisson.py
+++ b/tony/test_poisson.py
@@ -224,8 +224,7 @@ def run_experiment(config: PoissonSolverConfig, rank_val):
             mode=config.lr_patience_mode,
             factor=config.lr_factor,
             patience=config.lr_patience,
-            min_lr=config.lr_min,
-            verbose=True
+            min_lr=config.lr_min
         )
     else:
         lr_scheduler = None


### PR DESCRIPTION
The verbose argument is removed to have compaiblity of torch 1.x and torch 2.x

Latest version: https://docs.pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html

Torch 1.x version: 
https://docs.pytorch.org/docs/1.13/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html#torch.optim.lr_scheduler.ReduceLROnPlateau